### PR TITLE
added quit function and exception for keyboard interrupts. 

### DIFF
--- a/irc_client.py
+++ b/irc_client.py
@@ -17,6 +17,7 @@ def channel(channel):
 
 def quit():
     client.send_cmd("QUIT", "Good bye!")
+    print "Quitting ..."
     exit(0)
 
 class IRCSimpleClient:
@@ -95,13 +96,15 @@ if __name__ == "__main__":
             joined = True
             t = threading.Thread(target=client.print_response)
             t.start()
-
-    while(cmd != "/quit"):
-        cmd = raw_input("< {}> ".format(username)).strip()
-        if cmd == "/quit":
-            quit()
-        if cmd and len(cmd) > 0:
-            client.send_message_to_channel(cmd)
+    try:
+        while(cmd != "/quit"):
+            cmd = raw_input("< {}> ".format(username)).strip()
+            if cmd == "/quit":
+                quit()
+            if cmd and len(cmd) > 0:
+                client.send_message_to_channel(cmd)
+    except KeyboardInterrupt:
+        quit()
         
         t = threading.Thread(target=client.print_response)
         t.start()

--- a/irc_client.py
+++ b/irc_client.py
@@ -15,6 +15,9 @@ def channel(channel):
         return "#" + channel
     return channel
 
+def quit():
+    client.send_cmd("QUIT", "Good bye!")
+    exit(0)
 
 class IRCSimpleClient:
 
@@ -96,8 +99,7 @@ if __name__ == "__main__":
     while(cmd != "/quit"):
         cmd = raw_input("< {}> ".format(username)).strip()
         if cmd == "/quit":
-            client.send_cmd("QUIT", "Good bye!")
-            exit(0)
+            quit()
         if cmd and len(cmd) > 0:
             client.send_message_to_channel(cmd)
         


### PR DESCRIPTION
1. I added a quit function that sends the quit message, prints quitting ... and then exits
2. I also added a try, catch block around the input while loop that will gracefully exit the program if the user exits with ctrl and c (a keyboard interrupt).
Also, it's worth noting that it's not because of python that putting the # before the channel doesn't work. If you try it in single quotes, it'll work fine, but outside of single quotes, the shell itself will detect it as a comment, not allowing the channel to reach the python program.
